### PR TITLE
 Remove custom QtCreator depended configuration

### DIFF
--- a/ToggleSwitch.pro
+++ b/ToggleSwitch.pro
@@ -7,8 +7,8 @@
 QT       += widgets
 
 TARGET = ToggleSwitch
-TEMPLATE = lib
-CONFIG += staticlib
+TEMPLATE = app
+# CONFIG += staticlib
 
 # The following define makes your compiler emit warnings if you use
 # any feature of Qt which as been marked as deprecated (the exact warnings
@@ -21,7 +21,7 @@ DEFINES += QT_DEPRECATED_WARNINGS
 # You can also select to disable deprecated APIs only up to a certain version of Qt.
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
 
-SOURCES += toggleswitch.cpp
+SOURCES += toggleswitch.cpp main.cpp
 
 HEADERS += toggleswitch.hpp
 unix {

--- a/main.cpp
+++ b/main.cpp
@@ -1,0 +1,10 @@
+#include <QApplication>
+#include "toggleswitch.hpp"
+
+int main(int argc, char* argv[])
+{
+    QApplication app(argc, argv);
+    ToggleSwitch t;
+    t.show();
+    return app.exec();
+}

--- a/toggleswitch.cpp
+++ b/toggleswitch.cpp
@@ -35,7 +35,7 @@ void ToggleSwitch::paintEvent(QPaintEvent *event)
         painter.setBrush(this->m_bodyBrush);
         painter.setOpacity(1.0);
 
-        if(false == this->m_status)
+        if(true == this->m_status)
         {
             painter.drawEllipse(QRectF(this->width() - this->height(), (this->height() / 2) - (this->height() / 2),
                 this->height(), this->height()));


### PR DESCRIPTION
It is needless to provide this file in the repository, this file is specific to one setup of Qt Creator and this setup should done each time when somebody use this library.